### PR TITLE
download-generic.plugin: wget has flipped ftp passive/active option

### DIFF
--- a/plugins/download-generic.plugin
+++ b/plugins/download-generic.plugin
@@ -26,8 +26,8 @@ plugin_source_download_generic()  {
   # this is what the download will be stored as initially:
   TMP_FILE=$TMPDIR/$2
 
-  if [ "$FTP_ACTIVE" == "off" -o "$FTP_PASSIVE" == "on" ] ; then
-    WGET_OPTS+=" --passive-ftp"
+  if [ "$FTP_ACTIVE" == "on" -o "$FTP_PASSIVE" == "off" ] ; then
+    WGET_OPTS+=" --no-passive-ftp"
   fi
 
   if [ "$CONTINUE" == "off" ] ; then


### PR DESCRIPTION
passive ftp is now default in wget. To use active the option to use is now named --no-passive-ftp, this commit fixes that issue.
