### PR TITLE
Allow gather_docs to run from folders other then $SOURCE_DIRECTORY. There is no reason why we should restrict gather_docs to $SOURCE_DIRECTORY

### DIFF
--- a/plugins/postbuild-generic.plugin
+++ b/plugins/postbuild-generic.plugin
@@ -37,7 +37,6 @@ gather_docs()
 
   DOC_DIR=${DOCUMENT_DIRECTORY}/${MODULE}
   if [ -d "$SOURCE_DIRECTORY" ] ; then
-    cd $SOURCE_DIRECTORY
     mkdir -p $DOC_DIR
     # For each parameter that is an existing file
     for FILE in ${@}; do


### PR DESCRIPTION
Currently trying to gather docs with `gather_docs doc/xyz`
installs xyz to /usr/share/doc/$MODULE/doc/xyz.

With this patch we could just do `cd doc && gather_docs xyz` to
install the file to /usr/share/doc/$MODULE/xyz.
