### PR TITLE
add link-check to 'exists'

### DIFF
--- a/libs/misc.lunar
+++ b/libs/misc.lunar
@@ -123,7 +123,7 @@ exists() {
 	debug_msg "exists ($@)"
 	local ITEM
 	while read ITEM ; do
-		if [ -e "$ITEM" ] ; then
+		if [ -e "$ITEM" ] || [ -L "$ITEM" ]; then
 			echo "$ITEM"
 		fi
 	done


### PR DESCRIPTION
If I install a (temporarily) broken symlink, I don't want it to
be removed _here_. In the case of resolvconf I don't want it to
be removed at all.

resolvconf adds a link /etc/resolvconf/run/ -> /run/resolvconf.
As the /run/resolvconf folder is created in POST_INSTALL,
the symlink is fixed after the lin, but broken when the install logs
are written.
