### PR TITLE
syms_not_owned() causes symlinks to become alien

### DIFF
--- a/libs/build.lunar
+++ b/libs/build.lunar
@@ -327,21 +327,6 @@ default_post_build() {
 }
 
 
-syms_not_owned()  {
-  local DEST
-  debug_msg "syms_not_owned ($@)"
-  while read ITEM ; do
-    if [ -h "$ITEM" ] && [ -f "$ITEM" ]; then
-      DEST=$(basename $(ls -la "$ITEM" | cut -d '>' -f2 | cut -c 2- ) )
-      if ! grep -q "$DEST" "$1" ; then
-	    echo -n "$ITEM\|"
-        echo "$ITEM" >> $TMPDIR/$MODULE.rejected.symlinks
-      fi
-    fi
-  done < $1
-}
-
-
 prepare_module_config()  {
   debug_msg "prepare_module_config ($@)"
   if [ ! -e "$MODULE_CONFIG" ] ; then

--- a/libs/tracking.lunar
+++ b/libs/tracking.lunar
@@ -78,14 +78,7 @@ create_install_log() {
   echo "$COMPILE_LOGS/$MODULE-$VERSION.bz2"             >> $TMP_INST_LOG
   echo "$MD5SUM_LOGS/$MODULE-$VERSION"                  >> $TMP_INST_LOG
 
-  MISOWNED_SYMLINKS=$(syms_not_owned  $TMP_INST_LOG
-                      echo  -n  "/dev/null")
-
-  if [ "$MISOWNED_SYMLINKS" == "/dev/null" ] ; then
-    install -m644 $TMP_INST_LOG $INST_LOG
-  else
-    grep -v "$MISOWNED_SYMLINKS" "$TMP_INST_LOG" > $INST_LOG
-  fi
+  install -m644 $TMP_INST_LOG $INST_LOG
 
   temp_destroy $TMP_INST_LOG
 }


### PR DESCRIPTION
If a module create a symlink to a file that belong to another
module the core tools stripped these links from the install log
leaving the symlinks alien in the system. This proposal fix that
minor issue.
