### PR TITLE
Unalias dependency in in_depends()

### DIFF
--- a/libs/depends.lunar
+++ b/libs/depends.lunar
@@ -126,9 +126,12 @@ is_depends()  {
 
 
 in_depends()  {
+  local DEP
   debug_msg "in_depends ($@)"
+
+  DEP=$(unalias $2)
   # Was $2 presented as a dependency for module $1
-  return $(grep -q "^$1:$2:on:" "$DEPENDS_STATUS")
+  return $(grep -q "^$1:$DEP:on:" "$DEPENDS_STATUS")
 }
 
 


### PR DESCRIPTION
To properly be able to use if in_depends $MODULE %ALIAS in BUILD file in_depends() needs to unalias the dependency.
