### PR TITLE
automatically enter $SOURCE_DIRECTORY after default_pre_build

### DIFF
--- a/libs/build.lunar
+++ b/libs/build.lunar
@@ -142,7 +142,8 @@ default_pre_build() {
     fi
   else
     mk_source_dir        $SOURCE_DIRECTORY &&
-    unpack               $SOURCE
+    unpack               $SOURCE           &&
+    cd                   $SOURCE_DIRECTORY
   fi
 }
 


### PR DESCRIPTION
It is annoying to manually do this cd in _every_ PRE_BUILD file
