### PR TITLE
Make "unpack" deal with .xz-compressed files

### DIFF
--- a/plugins/unpack-generic.plugin
+++ b/plugins/unpack-generic.plugin
@@ -13,13 +13,9 @@
 
 plugin_unpack_generic() {
 	case $1 in
-		*tar.bz2|*tbz2)
-			debug_msg "Unpacking tar.bz2 file \"$1\""
-			tar jxf $1 --no-same-owner --no-same-permissions || return 1
-			;;
-		*tar.gz|*tgz|*tar.Z)
-			debug_msg "Unpacking tar.gz file \"$1\""
-			tar zxf $1 --no-same-owner --no-same-permissions || return 1
+		*tar.bz2|*tbz2|*.tar.gz|*.tgz|*.tar.Z|*.tar.xz|*.txz|*.tar)
+			debug_msg "Unpacking tar file \"$1\""
+			tar xf $1 --no-same-owner --no-same-permissions || return 1
 			;;
 		*.bz2)
 			debug_msg "Unpacking bz2 file \"$1\""
@@ -30,10 +26,6 @@ plugin_unpack_generic() {
 			debug_msg "Unpacking gz file \"$1\""
 			cp $1 . || return 1
 			gunzip $1 || return 1
-			;;
-		*.tar)
-			debug_msg "Unpacking tar  file \"$1\""
-			tar xf $1 --no-same-owner --no-same-permissions || return 1
 			;;
 		*)
 			# fallback: we don't know what to do!


### PR DESCRIPTION
Has this already been done by someone else?  The moonbase is full of .xz tar files these days, and it surprised me when lin couldn't unpack them automatically.

I actually took advantage of tar's ability to figure out how a file
is compressed for itself, and merged all of the different kinds of
tar unpack to a single command line.
