### PR TITLE
libs/build.lunar: Adding -Wno-dev to the default_cmake_config() to

### DIFF
--- a/libs/build.lunar
+++ b/libs/build.lunar
@@ -230,6 +230,7 @@ default_cmake_config() {
   cmake -DCMAKE_INSTALL_PREFIX=$MODULE_PREFIX  \
         -DCMAKE_BUILD_TYPE=RELEASE             \
         -DSYSCONF_INSTALL_DIR:PATH=/etc        \
+        -Wno-dev                               \
         $OPTS $SOURCE_DIRECTORY
 }
 


### PR DESCRIPTION
silence the proliferation of developer warnings. These are useless
to us and just pollutes the logs.
