### PR TITLE
Fixed a bug in the full URL generation.

### DIFF
--- a/libs/modules.lunar
+++ b/libs/modules.lunar
@@ -275,7 +275,7 @@ run_details() {
       [ -z "$URLS" ] && continue
 
       for IDX in ${!URLS[@]} ; do
-        eval $FULL_URL[$IDX]=\${URLS\[$IDX\]}-\${SRC}
+        eval $FULL_URL[$IDX]=\${URLS\[$IDX\]}\${SRC}
       done
     done
     MAX_SOURCES=$((CNT-1))


### PR DESCRIPTION
For some reason, it was pasting the path and the source filename
together with a hyphen between them.
