### PR TITLE
build.lunar: Adding another D switch to default_cmake_config disabling

### DIFF
--- a/libs/build.lunar
+++ b/libs/build.lunar
@@ -231,6 +231,7 @@ default_cmake_config() {
   cmake -DCMAKE_INSTALL_PREFIX=$MODULE_PREFIX  \
         -DCMAKE_BUILD_TYPE=RELEASE             \
         -DSYSCONF_INSTALL_DIR:PATH=/etc        \
+        -DBUILD_TESTING=0                      \
         -Wno-dev                               \
         $OPTS $SOURCE_DIRECTORY
 }


### PR DESCRIPTION
testing by default. If someone wants it they can always do -DBUILD_TESTING=1.
This won't catch all builds that use cmake, some use slightly different
verbiage to enable/disable the building of testing. But from what I have seen
it will catch most.

Like the -DSYSCONF_INSTALL_DIR switch, if a given cmake build does not recognize
the switch it will throw a harmless warning.