### PR TITLE
Simplify xterm title message code

### DIFF
--- a/libs/messages.lunar
+++ b/libs/messages.lunar
@@ -91,14 +91,8 @@ debug_msg() {
 # usage : xterm_msg MESSAGE
 # purpose : To display a short message in the title bar of a X terminal
 xterm_msg() {
-  local MSG
   debug_msg "xterm_bar ($@)"
-  case $TERM in
-    xterm*|gnome*|konsole*|rxvt*)
-      MSG="$HOSTNAME $(basename $0)[$$]: $@"
-      echo -n "]0; $MSG "
-      ;;
-  esac
+  echo -ne "\033]0;$HOSTNAME $(basename $0)[$$]: $@ \007"
 }
 
 # function : report FILE [description] MODULE VERSION


### PR DESCRIPTION
1. There's no reason for the restriction to some specific TERM. All terminals
I know or tested either support the sequence or ignore it without printing it
to the console (including linux terminal)

2. use escape sequences instead of cryptic bytes

3. no need for a local variable

4. strip leading/trailing whitespace. This simply doesn't belong there.