### PR TITLE
prog/lvu: Added a find function

### DIFF
--- a/prog/lvu
+++ b/prog/lvu
@@ -68,6 +68,8 @@ enforced                   display enforced modules
 expired                    display a list of modules which need an update
 info        module         display terse summary information about module
 
+find        "keyword"      displays modules with 'keyword' in their names,
+                              with their section
 search      "phrase"       searches all modules long descriptions for phrase.
 service     port|acronym   displays modules that provide that service
 
@@ -908,6 +910,19 @@ show_info() {
   fi
 }
 
+find_modules() {
+    shift
+    NSTR="-e $1.*:"
+
+    if [ ! -z "$2" ]; then
+        shift
+        for MODNAME in "$@"; do
+            NSTR="$NSTR -e $MODNAME.*:"
+        done
+    fi
+
+    grep -i $NSTR $MODULE_INDEX
+}
 
 diff_module() {
   if [ "$ZLOCAL_OVERRIDES" != "on" ]; then
@@ -1444,6 +1459,10 @@ main()  {
 
     POST_REMOVE)
       show_module_component $1 $2
+      ;;
+
+    find)
+      find_modules $@
       ;;
 
     search)


### PR DESCRIPTION
I checked the difference in time when using 'grep -E "(disk|file|util).*:" $MODULE_INDEX' and the -e regex is faster :) 400ms vs 90ms (this is with echo 3 > /proc/sys/vm/drop_caches )