### PR TITLE
plugins.lunar: Clean up the code a bit, simplify things.

### DIFF
--- a/libs/plugins.lunar
+++ b/libs/plugins.lunar
@@ -71,33 +71,43 @@ plugin_call() {
 
 
 update_plugin() {
-	local SECTION PLUGIN
+	local MODULE SECTION PLUGIN UPDATE_COMMAND
 	debug_msg "update_plugin($@)"
 	# update plugins of all modules or a specific one
 	#
 	# $1 - module name
-	# $2 - forced removal of plugin
+	# $2 - forced installation/removal of plugin
 	#
 	# scan module for plugins, and add/delete them as needed
-	if SECTION=$(find_section $1); then
-		if [ -d $MOONBASE/$SECTION/$1/plugin.d ]; then
-			if [ "$2" == "install" ] ; then
-				for PLUGIN in $MOONBASE/$SECTION/$1/plugin.d/*.plugin; do
-					debug_msg "Installed \"$(basename $PLUGIN)\""
-					install -m644 $PLUGIN $PLUGIN_DIR/
-				done
-			elif [ "$2" == "remove" ] || ! module_installed $1 ; then
-				for PLUGIN in $MOONBASE/$SECTION/$1/plugin.d/*.plugin; do
-					debug_msg "Removed \"$(basename $PLUGIN)\""
-					rm -f $PLUGIN_DIR/$(basename $PLUGIN)
-				done
-			else
-				for PLUGIN in $MOONBASE/$SECTION/$1/plugin.d/*.plugin; do
-					debug_msg "Installed \"$(basename $PLUGIN)\""
-					install -m644 $PLUGIN $PLUGIN_DIR/
-				done
-			fi
+	MODULE=$1
+	UPDATE_COMMAND=$2
+
+	# if an explicit command isn't given, figure out automatically
+	# whether to install plugins (for installed modules) or clean up
+	# plugins (for removed modules)
+	if [[ -z "$UPDATE_COMMAND" ]]; then
+		if module_installed $MODULE; then
+			UPDATE_COMMAND=install
+		else
+			UPDATE_COMMAND=remove
 		fi
+	fi
+
+	if SECTION=$(find_section $MODULE); then
+		for PLUGIN in $MOONBASE/$SECTION/$1/plugin.d/*.plugin
+		do
+			case $UPDATE_COMMAND in
+			install)
+				debug_msg "Installed \"$(basename $PLUGIN)\""
+				install -m 644 $PLUGIN $PLUGIN_DIR
+			;;
+
+			remove)
+				debug_msg "Removed \"$(basename $PLUGIN)\""
+				rm -f $PLUGIN_DIR/$(basename $PLUGIN)
+			;;
+			esac
+		done
 		reload_plugins
 	fi
 }
@@ -108,8 +118,9 @@ update_plugins() {
 	debug_msg "update_plugins($@)"
 	# find all plugins in moonbase and run update_plugin() on them
 	verbose_msg "Updating plugins"
-	find $MOONBASE -wholename "*/plugin.d/*.plugin" | while read PLUGIN ; do
-		update_plugin `basename $(echo $PLUGIN | sed 's/\/plugin.d\/.*//g')`
+	find $MOONBASE -wholename "*/plugin.d/*.plugin" | while read PLUGIN
+	do
+		update_plugin $(basename ${PLUGIN%/plugin.d/*})
 	done
 }
 


### PR DESCRIPTION
The previous plugins.lunar seemed to sometimes get confused about what
to do, leading to occasionally having plugins fail to be installed when
they should have been.  For instance, the dracut plugin on a fresh
install wasn't being installed, causing a fresh install to fail to boot
after installation finished.

This cleans up the code a bit to, with any luck, make that not happen as
much.