### PR TITLE
Added support for module types.

### DIFF
--- a/libs/build.lunar
+++ b/libs/build.lunar
@@ -180,7 +180,7 @@ cmake_build_target() {
 }
 
 
-default_gnu_config() {
+default_config() {
   debug_msg "default_gnu_config ($@)"
   verbose_msg "running \"default_gnu_config\""
   _configure  --build=$BUILD                      \
@@ -288,7 +288,7 @@ default_python3_build() {
 default_gnu_build() {
   debug_msg "default_build ($@)"
   verbose_msg "running \"default_build\""
-  default_gnu_config  &&
+  default_config  &&
   default_make
 }
 

--- a/libs/build.lunar
+++ b/libs/build.lunar
@@ -180,9 +180,9 @@ cmake_build_target() {
 }
 
 
-default_config() {
-  debug_msg "default_config ($@)"
-  verbose_msg "running \"default_config\""
+default_gnu_config() {
+  debug_msg "default_gnu_config ($@)"
+  verbose_msg "running \"default_gnu_config\""
   _configure  --build=$BUILD                      \
               --prefix=$MODULE_PREFIX             \
               --sysconfdir=/etc                   \
@@ -238,12 +238,10 @@ default_cmake_config() {
         $OPTS $SOURCE_DIRECTORY
 }
 
-
 default_install() {
     prepare_install &&
     make install
 }
-
 
 default_make() {
   debug_msg "default_make ($@)"
@@ -268,14 +266,45 @@ default_cmake_build() {
   default_make
 }
 
+default_perl_build() {
+    debug_msg "default_perl_build ($@)"
+    verbose_msg "running \"default_perl_build\""
+    perl Makefile.PL &&
+    default_make
+}
+
+default_python2_build() {
+    python2 setup.py build &&
+    prepare_install &&
+    python2 setup.py install
+}
+
+default_python3_build() {
+    python3 setup.py build &&
+    prepare_install &&
+    python3 setup.py install
+}
+
+default_gnu_build() {
+  debug_msg "default_build ($@)"
+  verbose_msg "running \"default_build\""
+  default_gnu_config  &&
+  default_make
+}
 
 default_build() {
   debug_msg "default_build ($@)"
   verbose_msg "running \"default_build\""
-  default_config  &&
-  default_make
-}
 
+    case "$TYPE" in
+        python2) default_python2_build ;;
+        python3) default_python3_build ;;
+        cpan)    default_cpan_build    ;;
+        perl)    default_perl_build    ;;
+        cmake)   default_cmake_build   ;;
+        *)       default_gnu_build     ;;
+    esac
+}
 
 default_cvs_build() {
   debug_msg "default_cvs_build ($@)"

--- a/libs/build.lunar
+++ b/libs/build.lunar
@@ -181,8 +181,8 @@ cmake_build_target() {
 
 
 default_config() {
-  debug_msg "default_gnu_config ($@)"
-  verbose_msg "running \"default_gnu_config\""
+  debug_msg "default_config ($@)"
+  verbose_msg "running \"default_config\""
   _configure  --build=$BUILD                      \
               --prefix=$MODULE_PREFIX             \
               --sysconfdir=/etc                   \
@@ -301,6 +301,7 @@ default_build() {
         python3) default_python3_build ;;
         cpan)    default_cpan_build    ;;
         perl)    default_perl_build    ;;
+        game)    default_game_build    ;;
         cmake)   default_cmake_build   ;;
         *)       default_gnu_build     ;;
     esac


### PR DESCRIPTION
This lets you add a line saying "TYPE=perl" or "TYPE=python2" or
"TYPE=cmake" to a module's DETAILS file to save on having to write
a BUILD script that just has "default_cmake_build" in it.