### PR TITLE
installwatch: omit fchmod & access

### DIFF
--- a/libs/tracking.lunar
+++ b/libs/tracking.lunar
@@ -51,7 +51,7 @@ devoke_installwatch() {
 parse_iw() {
   local OMIT_IN
   debug_msg "parse_iw ($@)"
-  OMIT_IN="	rename\|	symlink\|	unlink"
+  OMIT_IN="	rename\|	symlink\|	unlink\|	fchmod\|	access"
 
   grep -v "$OMIT_IN" "$INSTALLWATCHFILE" | cut -f3 | grep -v "^$SOURCE_DIRECTORY" | grep -v -f "$EXCLUDED"
   cat                "$INSTALLWATCHFILE" | cut -f4 | grep -v "^$SOURCE_DIRECTORY" | grep -v -f "$EXCLUDED" | grep "^/"


### PR DESCRIPTION
fchmod applies to a file descriptor, so it's just not helpful.

access is disabled in our installwatch/BUILD module,
but if you build installwatch by hand and you miss the flag,
it suddenly starts tracking all kind of files it's not supposed to.

I believe there's no harm in removing them here.