### PR TITLE
Tmpfs build: add an option to build modules in a tmpfs instead of on disk

### DIFF
--- a/etc/config
+++ b/etc/config
@@ -65,6 +65,7 @@ export        DIALOGRC=/etc/lunar/dialogrc
          PROMPT_DELAY=${PROMPT_DELAY:-150}
         PROBE_EXPIRED=${PROBE_EXPIRED:-on}
        LUNAR_PRIORITY="+10"
+          TMPFS_BUILD=${TMPFS_BUILD:-off}
 
             LDD_CHECK=${LDD_CHECK:-on}
            FIND_CHECK=${FIND_CHECK:-on}

--- a/libs/sources.lunar
+++ b/libs/sources.lunar
@@ -163,6 +163,10 @@ rm_source_dir() {
   DEAD_DIR=${DEAD_DIR:-$SOURCE_DIRECTORY}
 
   verbose_msg "destroying building dir \"$DEAD_DIR\""
+  if grep -q $DEAD_DIR /proc/mounts
+  then
+    umount $DEAD_DIR
+  fi
   rm -rf $DEAD_DIR 2> /dev/null
 }
 
@@ -186,6 +190,10 @@ mk_source_dir() {
     rm -rf $NEW_DIR 2>/dev/null
   fi
   mkdir -p $NEW_DIR
+  if [ ${KEEP_SOURCE:-off} != on -a ${TMPFS_BUILD:-off} == on ]
+  then
+    mount -t tmpfs tmpfs $NEW_DIR
+  fi
 }
 
 

--- a/libs/sources.lunar
+++ b/libs/sources.lunar
@@ -1,4 +1,4 @@
-#!/bin/bash
+#/bin/bash
 ############################################################
 #                                                          #
 # This code is written for Lunar Linux, see                #
@@ -187,7 +187,7 @@ mk_source_dir() {
   verbose_msg "creating building dir \"$NEW_DIR\""
   if [ -d $NEW_DIR ] ; then
     verbose_msg "Removing old source directory first!"
-    rm -rf $NEW_DIR 2>/dev/null
+    rm_source_dir $NEW_DIR
   fi
   mkdir -p $NEW_DIR
   if [ ${KEEP_SOURCE:-off} != on -a ${TMPFS_BUILD:-off} == on ]

--- a/libs/sources.lunar
+++ b/libs/sources.lunar
@@ -192,6 +192,10 @@ mk_source_dir() {
   mkdir -p $NEW_DIR
   if [ ${KEEP_SOURCE:-off} != on -a ${TMPFS_BUILD:-off} == on ]
   then
+    if grep $NEW_DIR /proc/mounts > /dev/null
+    then
+      umount $NEW_DIR
+    fi
     mount -t tmpfs tmpfs $NEW_DIR
   fi
 }


### PR DESCRIPTION
This can make builds go much faster if you have lots of RAM.

The default is "off" though because maybe you're not that bold.