### PR TITLE
ignore hidden files in patch folders

### DIFF
--- a/plugins/build-zpatches.plugin
+++ b/plugins/build-zpatches.plugin
@@ -34,7 +34,8 @@ plugin_zpatches_apply()
     # Now find all patches and apply them
     # We also sort them so it possible to apply patch order
     # by prefixing a patch with 01, 02, 03 etc
-    find $PATCHDIRS -maxdepth 1 -type f | sed 's;[^/]*$;& &;' | sort -t ' ' -k 2 | while read FPATCH PATCH; do
+	 # ignore hidden files
+    find $PATCHDIRS -maxdepth 1 -type f -name '[^\.]*' | sed 's;[^/]*$;& &;' | sort -t ' ' -k 2 | while read FPATCH PATCH; do
       verbose_msg "Applying $PATCH for $MODULE"
 
       if [[ -n `echo $PATCH | grep '\.tar'` ]] ; then


### PR DESCRIPTION
When editing a patch in your favorite editor,
the editor will create hidden save files.

Our patch system should not pick up on them.