### PR TITLE
Shellcheck suggestions: menus

### DIFF
--- a/menu/alias.menu
+++ b/menu/alias.menu
@@ -1,3 +1,4 @@
+#! /bin/bash
 ############################################################
 #                                                          #
 # This code is written for Lunar Linux, see                #
@@ -12,74 +13,71 @@
 
 alias_menu_list_aliases()
 {
-	for A in `cut -d: -f1 "$MOONBASE/aliases"`; do
-		echo ${A:1}
-		CHOICE=$(get_local_config `echo LUNAR_ALIAS_${A:1}`)
-		if [ -n "$CHOICE" ] ; then
-			echo "$CHOICE"
-		else
-			echo "[unset]"
-		fi
-	done
+    cut -d: -f1 "$MOONBASE/aliases" | while read -r A; do
+        echo "${A:1}"
+        CHOICE=$(get_local_config "LUNAR_ALIAS_${A:1}")
+        if [ -n "$CHOICE" ] ; then
+            echo "$CHOICE"
+        else
+            echo "[unset]"
+        fi
+    done
 }
 
 
 alias_menu_list_alias_choices()
 {
-	echo "None"
-	echo "None"
-	if [ -z "$(get_local_config `echo LUNAR_ALIAS_$1`)" ] ; then
-		echo "on"
-	else
-		echo "off"
-	fi
-	IFS=$STANDARD_IFS
-	for C in `grep "^%$1:" "$MOONBASE/aliases" | cut -d: -f2`; do
-		echo "$C"
-		echo "$C"
-		if [ $(get_local_config `echo LUNAR_ALIAS_$1`) == "$C" ] ; then
-			echo "on"
-		else
-			echo "off"
-		fi
-	done
+    echo "None"
+    echo "None"
+    if [ -z "$(get_local_config "LUNAR_ALIAS_$1")" ] ; then
+        echo "on"
+    else
+        echo "off"
+    fi
+    IFS=$STANDARD_IFS
+    grep "^%$1:" "$MOONBASE/aliases" | cut -d: -f2 | while read -r C; do
+        echo "$C"
+        echo "$C"
+        if [ "$(get_local_config "LUNAR_ALIAS_$1")" == "$C" ] ; then
+            echo "on"
+        else
+            echo "off"
+        fi
+    done
 }
 
 
 select_aliases()
 {
-	export IFS=$ENTER_IFS
+    local CHOICE
+    export IFS=$ENTER_IFS
 
-	while true ; do
-		DEFAULT=${CHOICE}
-		CHOICE=`$DIALOG --title "Select Lunar Aliases" \
-		                --ok-label "Select" \
-		                --cancel-label "Close" \
-		                --default-item "$DEFAULT" \
-		                --menu "" 0 0 0 \
-		                $(alias_menu_list_aliases)`
-		if [ $? != 0 ]; then
-			return
-		fi
+    while true ; do
+        DEFAULT="$CHOICE"
+        CHOICE=$("$DIALOG" --title "Select Lunar Aliases" \
+                           --ok-label "Select" \
+                           --cancel-label "Close" \
+                           --default-item "$DEFAULT" \
+                           --menu "" 0 0 0 \
+                           "$(alias_menu_list_aliases)") || return
 
-		# modify an alias
-		DEFAULT=$(get_local_config `echo LUNAR_ALIAS_$CHOICE`)
-		if [ -z "$DEFAULT" ] ; then
-			DEFAULT="None"
-		fi
-		ACHOICE=`$DIALOG --title "Select Lunar Aliases" \
-		                 --ok-label "Select" \
-		                 --cancel-label "Close" \
-		                 --default-item "$DEFAULT" \
-		                 --radiolist "" 0 0 0 \
-		                 $(alias_menu_list_alias_choices $CHOICE)`
-		if [ $? == 0 ]; then
-			# modify it
-			if [ "$ACHOICE" != "None" ] ; then
-				set_local_config `echo LUNAR_ALIAS_$CHOICE` "$ACHOICE"
-			else
-				unset_local_config `echo LUNAR_ALIAS_$CHOICE`
-			fi
-		fi
-	done
+        # modify an alias
+        DEFAULT=$(get_local_config "LUNAR_ALIAS_$CHOICE")
+        if [ -z "$DEFAULT" ] ; then
+            DEFAULT="None"
+        fi
+        if ACHOICE=$("$DIALOG" --title "Select Lunar Aliases" \
+                               --ok-label "Select" \
+                               --cancel-label "Close" \
+                               --default-item "$DEFAULT" \
+                               --radiolist "" 0 0 0 \
+                              "$(alias_menu_list_alias_choices "$CHOICE")")
+        then
+            if [ "$ACHOICE" != "None" ] ; then
+                set_local_config "LUNAR_ALIAS_$CHOICE" "$ACHOICE"
+            else
+                unset_local_config "LUNAR_ALIAS_$CHOICE"
+            fi
+        fi
+    done
 }

--- a/menu/download.menu
+++ b/menu/download.menu
@@ -1,3 +1,4 @@
+#! /bin/bash
 ############################################################
 #                                                          #
 # This code is written for Lunar Linux, see                #
@@ -20,58 +21,55 @@
 
 
 inputbox()  {
-
   $DIALOG  --nocancel                     \
            --inputbox                     \
            "$1"  0 0  "$2"
 }
 
 configure_proxy() {
-
-   HTTP_PROMPT="Please enter the HTTP proxy server. \
+    HTTP_PROMPT="Please enter the HTTP proxy server. \
 Example: http://192.168.1.1:8080/"
 
     FTP_PROMPT="Please enter the FTP proxy server. \
 Example: http://192.168.1.1:8080/"
 
-     NO_PROMPT="Please enter all domains/ip addresses \
+    NO_PROMPT="Please enter all domains/ip addresses \
 (comma-separated) proxy should NOT be used for: \
 Example: .mit.edu,mysite.com"
 
-    HPROXY=`inputbox "$HTTP_PROMPT" "$http_proxy"` &&
-    
+    HPROXY=$(inputbox "$HTTP_PROMPT" "$http_proxy") &&
+
     [ "$ftp_proxy" == "" ] && ftp_proxy="$HPROXY"
 
-    FPROXY=`inputbox "$FTP_PROMPT" "$ftp_proxy"`   &&
-    NPROXY=`inputbox "$NO_PROMPT"  "$no_proxy"`
-    
+    FPROXY=$(inputbox "$FTP_PROMPT" "$ftp_proxy")   &&
+    NPROXY=$(inputbox "$NO_PROMPT"  "$no_proxy")
+
 }
 
 confirm_proxy_settings() {
+    confirm() {
+        $DIALOG "$2" --nocancel --yesno  "$1"  8 50
+    }
 
-  confirm()  {
-    $DIALOG  $2  --nocancel  --yesno  "$1"  8 50
-  }
+    FINISHED=NO
 
-  FINISHED=NO
+    while [ "$FINISHED" != "YES" ] ; do
+        PROMPT="Are these settings correct?"
+        PROMPT="$PROMPT\nHTTP Proxy:  $HPROXY"
+        PROMPT="$PROMPT\n FTP Proxy:  $FPROXY"
+        PROMPT="$PROMPT\n  No Proxy:  $NPROXY"
 
-  while [ "$FINISHED" != "YES" ] ; do
-    PROMPT="Are these settings correct?"
-    PROMPT="$PROMPT\nHTTP Proxy:  $HPROXY"
-    PROMPT="$PROMPT\n FTP Proxy:  $FPROXY"
-    PROMPT="$PROMPT\n  No Proxy:  $NPROXY"
+        if confirm "$PROMPT" "--cr-wrap" ; then
+            FINISHED=YES
+        else
+            configure_proxy
+            FINISHED=NO
+        fi
+    done
 
-    if confirm "$PROMPT" "--cr-wrap" ; then
-       FINISHED=YES
-    else
-       configure_proxy
-       FINISHED=NO
-    fi
-  done
-
-  set_local_config "http_proxy" "$HPROXY" 
-  set_local_config "ftp_proxy" "$FPROXY"
-  set_local_config "no_proxy" "$NPROXY"
+    set_local_config "http_proxy" "$HPROXY"
+    set_local_config "ftp_proxy" "$FPROXY"
+    set_local_config "no_proxy" "$NPROXY"
 }
 
 proxy_exit_message() {
@@ -79,255 +77,245 @@ proxy_exit_message() {
     $DIALOG  --cr-wrap                                 \
              --title  "Lunar Proxy Settings Complete"  \
              --msgbox                                  \
-"Your proxy configuration has been saved.
+             "Your proxy configuration has been saved.
 
-Please note that these proxy settings will only be used by 
+Please note that these proxy settings will only be used by
 Lunar (wget) and possibly some other command-line utilities.
 
-You will still have to configure proxy settings in your 
+You will still have to configure proxy settings in your
 favorite web browser, etc..." 12 65
-
 }
 
-proxy_menu()
-{
-   configure_proxy
-   confirm_proxy_settings
-   proxy_exit_message
+proxy_menu() {
+    configure_proxy
+    confirm_proxy_settings
+    proxy_exit_message
 }
 
 download_options() {
+    set_download_rate() {
+        PROMPT="Please enter the maximum bytes per second for lgeting. \
+    Example: enter 8000 for downloading no faster then \
+    8 kBps, 80k for 80 kBps, or 1m for 1mBps"
 
-set_download_rate()  {
-  PROMPT="Please enter the maximum bytes per second for lgeting. \
-Example: enter 8000 for downloading no faster then \
-8 kBps, 80k for 80 kBps, or 1m for 1mBps"
+        if  DOWNLOAD_RATE=$($DIALOG  --title "Download Rate" \
+                                     --ok-label  "Commit"    \
+                                     --inputbox              \
+                                     "$PROMPT"               \
+                                     0 0  "$DOWNLOAD_RATE")
+      then
+          set_local_config "DOWNLOAD_RATE" "$DOWNLOAD_RATE"
+      fi
+    }
 
-  if  DOWNLOAD_RATE=`$DIALOG  --title "Download Rate" \
-                              --ok-label  "Commit"    \
-                              --inputbox              \
-                              "$PROMPT"               \
-                               0 0  "$DOWNLOAD_RATE"`
-  then
-    set_local_config "DOWNLOAD_RATE" "$DOWNLOAD_RATE"
-  fi
-}
+    set_repository_threshold() {
+        PROMPT="Please enter the minimum time between repository updates in minutes, \
+    enter 0 for no threshold. Default threshold is 10 minutes"
 
-set_repository_threshold()  {
-  PROMPT="Please enter the minimum time between repository updates in minutes, \
-enter 0 for no threshold. Default threshold is 10 minutes"
+        if  REPOSITORY_THRESHOLD=$($DIALOG  --title "Repository threshold" \
+                                            --ok-label  "Commit"           \
+                                            --inputbox                     \
+                                            "$PROMPT"                      \
+                                             0 0  "$REPOSITORY_THRESHOLD")
+        then
+            set_local_config "REPOSITORY_THRESHOLD" "$REPOSITORY_THRESHOLD"
+        fi
+    }
 
-  if  REPOSITORY_THRESHOLD=`$DIALOG  --title "Repository threshold" \
-                              --ok-label  "Commit"    \
-                              --inputbox              \
-                              "$PROMPT"               \
-                               0 0  "$REPOSITORY_THRESHOLD"`
-  then
-    set_local_config "REPOSITORY_THRESHOLD" "$REPOSITORY_THRESHOLD"
-  fi
-}
+    set_ftp_active() {
+        PROMPT="Please select the connection type for ftp downloads.
 
+    Passive ftp is the safe and default option. However, if you
+    are behind a weird firewall, or if you are experiencing
+    download problems, select active ftp option.
 
+    This option can also be set per module basis. Add
+    FTP_ACTIVE=on in DETAILS file :=) or vice-versa."
 
-set_ftp_active(){
+        FTP_ACTIVE=${FTP_ACTIVE:-off}
+        FTP_PASSIVE=${FTP_PASSIVE:-on}
 
-   PROMPT="Please select the connection type for ftp downloads.
+        [ "$FTP_ACTIVE" == "on" ] &&
+            FTP_PASSIVE=off ||
+            FTP_PASSIVE=on
 
-Passive ftp is the safe and default option. However, if you
-are behind a weird firewall, or if you are experiencing
-download problems, select active ftp option.
+        FTP_CONNECTION=$("$DIALOG" --title "Ftp Connection"           \
+                                   --ok-label  "Commit"               \
+                                   --radiolist                        \
+                                   "$PROMPT"                          \
+                                   0 0 0                              \
+                       "Passive" "normal behaviour"   "$FTP_PASSIVE"  \
+                       "Active"  "behind a firewall"  "$FTP_ACTIVE")
 
-This option can also be set per module basis. Add
-FTP_ACTIVE=on in DETAILS file :=) or vice-versa."
+        case $FTP_CONNECTION in
+            Active)  FTP_ACTIVE=on ;;
+            Passive) FTP_ACTIVE=off ;;
+        esac
 
-   FTP_ACTIVE=${FTP_ACTIVE:-off}
-   FTP_PASSIVE=${FTP_PASSIVE:-on}
+        set_local_config "FTP_ACTIVE" "$FTP_ACTIVE"
+    }
 
-   [ "$FTP_ACTIVE" == "on" ] && 
-   FTP_PASSIVE=off || 
-   FTP_PASSIVE=on
+    set_ipv46() {
+        local USE_IPV4 USE_IPV6 USE_IPVANY
 
-   FTP_CONNECTION=`$DIALOG  --title "Ftp Connection" \
-                            --ok-label  "Commit"     \
-                            --radiolist              \
-                            "$PROMPT"                \
-                             0 0 0                   \
-                  "Passive" "normal behaviour"   $FTP_PASSIVE  \
-                  "Active"  "behind a firewall"  $FTP_ACTIVE`
+        PROMPT="Please select the internet protocol version
+    to use when downloading modules."
+        USE_IPV4=off
+        USE_IPV6=off
+        USE_IPVANY=off
 
-   case $FTP_CONNECTION in
-      Active)  FTP_ACTIVE=on
-               ;;
+        if [ "$USE_IPV46" == "4" ]; then
+            USE_IPV4=on
+        elif [ "$USE_IPV46" == "6" ]; then
+            USE_IPV6=on
+        else
+            USE_IPVANY=on
+        fi
 
-      Passive)  FTP_ACTIVE=off
-               ;;
-   esac
-   
-   set_local_config "FTP_ACTIVE" "$FTP_ACTIVE"
-}
+        USE_IPV46=$($DIALOG  --title "Internet protocol version"                \
+                             --ok-label  "Commit"                               \
+                             --radiolist                                        \
+                             "$PROMPT"                                          \
+                             0 0 0                                              \
+                             "Any" "Use system default" $USE_IPVANY             \
+                             "4" "Internet protocol version 4 (ipv4)" $USE_IPV4 \
+                             "6" "Internet protocol version 6 (ipv6)"  $USE_IPV6)
+        if [ "$USE_IPV46" = "Any" ]; then
+            unset_local_config "USE_IPV46"
+        else
+            set_local_config "USE_IPV46" "$USE_IPV46"
+        fi
+    }
 
-set_ipv46() {
-  local USE_IPV4 USE_IPV6 USE_IPVANY
+    set_partial_downloads() {
+        PROMPT="Please enable/disable the partial download option.
 
-  PROMPT="Please select the internet protocol version
-to use when downloading modules."
-  USE_IPV4=off
-  USE_IPV6=off
-  USE_IPVANY=off
+    This is the -c option of wget. Enable is default
+    and works fine on almost all cases.
 
-  if [ "$USE_IPV46" == "4" ]; then
-    USE_IPV4=on
-  elif [ "$USE_IPV46" == "6" ]; then
-    USE_IPV6=on
-  else
-    USE_IPVANY=on
-  fi
+    This option can also be set per module basis. Add
+    CONTINUE=off in DETAILS file :=) or vice-versa."
 
-  USE_IPV46=$($DIALOG  --title "Internet protocol version" \
-                    --ok-label  "Commit"     \
-                    --radiolist              \
-                    "$PROMPT"                \
-                    0 0 0                   \
-                    "Any" "Use system default" $USE_IPVANY \
-                    "4" "Internet protocol version 4 (ipv4)" $USE_IPV4  \
-                    "6" "Internet protocol version 6 (ipv6)"  $USE_IPV6)
-  if [ "$USE_IPV46" = "Any" ]; then
-    unset_local_config "USE_IPV46"
-  else
-    set_local_config "USE_IPV46" "$USE_IPV46"
-  fi
-}
+        CONTINUE="${CONTINUE:-on}"
 
-set_partial_downloads(){
+        PARTIAL=$("$DIALOG" --title "Partial Downloads" \
+                            --ok-label  "Commit"        \
+                            --checklist                 \
+                            "$PROMPT"                   \
+                            0 0 0                       \
+                            "Enable" "partial downloads" "$CONTINUE")
 
-   PROMPT="Please enable/disable the partial download option.
+        #lets get rid of " and spaces in the variable
+        PARTIAL="${PARTIAL//\"/}"
+        PARTIAL="${PARTIAL// /}"
 
-This is the -c option of wget. Enable is default
-and works fine on almost all cases.
+        if [ "$PARTIAL" == "Enable" ] ; then
+            set_local_config "CONTINUE" "on"
+        else
+            set_local_config "CONTINUE" "off"
+        fi
+    }
 
-This option can also be set per module basis. Add
-CONTINUE=off in DETAILS file :=) or vice-versa."
+    set_cache_usage() {
+        PROMPT="Please enable/disable the cache usage.
 
-   CONTINUE=${CONTINUE:-on}
+    This options controls the use of cache for http downloads.
+    Default is ON. If this option is set to off, wget will send
+    a Pragma: no-cache directive to http server.
 
-   PARTIAL=`$DIALOG  --title "Partial Downloads" \
-                            --ok-label  "Commit" \
-                            --checklist          \
-                            "$PROMPT"            \
-                             0 0 0               \
-                  "Enable" "partial downloads" $CONTINUE`
+    This option can also be set per module basis. Add
+    USE_CACHE=off in DETAILS file :=) or vice-versa."
 
-   #lets get rid of " and spaces in the variable
-   PARTIAL=`echo $PARTIAL | sed s/\"//g | tr -d " "`
+        USE_CACHE=${USE_CACHE:-on}
 
-   if [ "$PARTIAL" == "Enable" ] ; then
-     set_local_config "CONTINUE" "on"
-   else
-     set_local_config "CONTINUE" "off"
-   fi
-}
+        CACHE=$("$DIALOG" --title "Cache Usage" \
+                          --ok-label  "Commit"  \
+                          --checklist           \
+                          "$PROMPT"             \
+                          0 0 0                 \
+                          "Enable" "http cache usage" "$USE_CACHE")
 
+        # let's get rid of " and spaces in the variable
+        CACHE="${CACHE//\"/}"
+        CACHE="${CACHE// /}"
 
-set_cache_usage(){
+        if [ "$CACHE" == "Enable" ] ; then
+            set_local_config "USE_CACHE" "on"
+        else
+            set_local_config "USE_CACHE" "off"
+        fi
+    }
 
-   PROMPT="Please enable/disable the cache usage.
+    set_retries() {
+        PROMPT="Please enter the maximum number of retries.
 
-This options controls the use of cache for http downloads.
-Default is ON. If this option is set to off, wget will send
-a Pragma: no-cache directive to http server.
+    Example: enter 3 for retrying the download three times.
+    The default value (if unset) is 5. Enter 0 for infinite
+    number of retries.
 
-This option can also be set per module basis. Add
-USE_CACHE=off in DETAILS file :=) or vice-versa."
+    This option can also be set per module basis. Add
+    NUM_RETRY=<n> in DETAILS file :=)"
 
-   USE_CACHE=${USE_CACHE:-on}
+        NUM_RETRY=${NUM_RETRY:-5}
 
-   CACHE=`$DIALOG  --title "Cache Usage" \
-                            --ok-label  "Commit" \
-                            --checklist          \
-                            "$PROMPT"            \
-                             0 0 0               \
-                  "Enable" "http cache usage" $USE_CACHE`
+        if  NUM_RETRY=$($DIALOG  --title "Number of Retries" \
+                                 --ok-label  "Commit"        \
+                                 --inputbox                  \
+                                 "$PROMPT"                   \
+                                  0 0  "$NUM_RETRY")
+        then
+            set_local_config "NUM_RETRY" "$NUM_RETRY"
+        fi
+    }
 
-   #lets get rid of " and spaces in the variable
-   CACHE=`echo $CACHE | sed s/\"//g | tr -d " "`
+    set_exhaustive() {
+        PROMPT="If you want, lget may try downloading the file from all
+    available mirrors, instead of the one you select from the mirror
+    menu. All mirrors will be tried until the file is found.
 
-   if [ "$CACHE" == "Enable" ] ; then
-     set_local_config "USE_CACHE" "on"
-   else
-     set_local_config "USE_CACHE" "off"
-   fi
-}
+    This is not recommended for normal downloads, broken downloads
+    should be reported to maintainer@lunar-linux.org.
+    "
 
-set_retries()  {
-  PROMPT="Please enter the maximum number of retries. 
+        EXHAUSTIVE=${EXHAUSTIVE:-off}
 
-Example: enter 3 for retrying the download three times.
-The default value (if unset) is 5. Enter 0 for infinite
-number of retries.
+        EXHAUSTIVE=$($DIALOG  --title "Exhaustive mirror testing: " \
+                              --ok-label  "Commit" \
+                              --checklist          \
+                              "$PROMPT"            \
+                               0 0 0               \
+                              "Enable" "exhaustive mirror testing" "$EXHAUSTIVE")
 
-This option can also be set per module basis. Add
-NUM_RETRY=<n> in DETAILS file :=)"
-
-  NUM_RETRY=${NUM_RETRY:-5}
-
-  if  NUM_RETRY=`$DIALOG  --title "Number of Retries" \
-                          --ok-label  "Commit"        \
-                           --inputbox               \
-                           "$PROMPT"                \
-                            0 0  "$NUM_RETRY"`
-  then
-    set_local_config "NUM_RETRY" "$NUM_RETRY"
-  fi
-}
-
-set_exhaustive() {
-  PROMPT="If you want, lget may try downloading the file from all
-available mirrors, instead of the one you select from the mirror
-menu. All mirrors will be tried until the file is found.
-
-This is not recommended for normal downloads, broken downloads
-should be reported to maintainer@lunar-linux.org.
-"
-
-  EXHAUSTIVE=${EXHAUSTIVE:-off}
-
-  EXHAUSTIVE=`$DIALOG  --title "Exhaustive mirror testing: " \
-             --ok-label  "Commit" \
-             --checklist          \
-             "$PROMPT"            \
-              0 0 0               \
-             "Enable" "exhaustive mirror testing" $EXHAUSTIVE`
-
-  EXHAUSTIVE=`echo $EXHAUSTIVE | sed s/\"//g | tr -d " "`
-
-  if [ "$EXHAUSTIVE" == "Enable" ] ; then
-    set_local_config "EXHAUSTIVE" "on"
-  else
-    set_local_config "EXHAUSTIVE" "off"
-  fi
-
-}
+        # Get rid of " and spaces from the result
+        EXHAUSTIVE="${EXHAUSTIVE//\"/}"
+        EXHAUSTIVE="${EXHAUSTIVE// /}"
 
 
+        if [ "$EXHAUSTIVE" == "Enable" ] ; then
+            set_local_config "EXHAUSTIVE" "on"
+        else
+            set_local_config "EXHAUSTIVE" "off"
+        fi
+    }
 
-while
-    A_HELP="Active or passive connections while using ftp"
-    C_HELP="Continue to get or re-get the partial downloads"
-    N_HELP="How many times will wget try to download the file?"
-    H_HELP="Cache usage for http downloads"
-    I_HELP="Internet protocol version to use when downloading a file"
-    R_HELP="Per process download rate"
-    P_HELP="Proxy Settings"
-    E_HELP="Test all mirrors available on download"
-    T_HELP="Repository update threshold time"
+    while
+        A_HELP="Active or passive connections while using ftp"
+        C_HELP="Continue to get or re-get the partial downloads"
+        N_HELP="How many times will wget try to download the file?"
+        H_HELP="Cache usage for http downloads"
+        I_HELP="Internet protocol version to use when downloading a file"
+        R_HELP="Per process download rate"
+        P_HELP="Proxy Settings"
+        E_HELP="Test all mirrors available on download"
+        T_HELP="Repository update threshold time"
 
-    COMMAND=`$DIALOG  --title "Download Options"               \
-                      --item-help                              \
-                      --ok-label      "Select"                 \
-                      --cancel-label  "Exit"                   \
-                      --menu                                   \
-                      ""                                       \
-                      0 40 8                                   \
+        COMMAND=$($DIALOG  --title "Download Options"               \
+                           --item-help                              \
+                           --ok-label      "Select"                 \
+                           --cancel-label  "Exit"                   \
+                           --menu                                   \
+                           ""                                       \
+                           0 40 8                                   \
                       "A"  "Ftp Active/Passive"          "$A_HELP"  \
                       "C"  "Partial Downloads"           "$C_HELP"  \
                       "H"  "Cache Usage"                 "$H_HELP"  \
@@ -335,21 +323,20 @@ while
                       "N"  "Number of Retries"           "$N_HELP"  \
                       "P"  "Proxies"                     "$P_HELP"  \
                       "R"  "Download Rate"               "$R_HELP"  \
-		      "E"  "Exhaustive mirrors"          "$E_HELP"  \
-		      "T"  "Repository update threshold" "$T_HELP"`
+                      "E"  "Exhaustive mirrors"          "$E_HELP"  \
+                      "T"  "Repository update threshold" "$T_HELP")
 
-  do
-    case  $COMMAND in
-      A)  set_ftp_active           ;;
-      C)  set_partial_downloads    ;;
-      H)  set_cache_usage          ;;
-      I)  set_ipv46                ;;
-      N)  set_retries              ;;
-      P)  proxy_menu               ;;
-      R)  set_download_rate        ;;
-      E)  set_exhaustive           ;;
-      T)  set_repository_threshold ;;
-    esac
-  done
+    do
+        case  $COMMAND in
+            A)  set_ftp_active           ;;
+            C)  set_partial_downloads    ;;
+            H)  set_cahe_usage           ;;
+            I)  set_ipv46                ;;
+            N)  set_retries              ;;
+            P)  proxy_menu               ;;
+            R)  set_download_rate        ;;
+            E)  set_exhaustive           ;;
+            T)  set_repository_threshold ;;
+        esac
+    done
 }
-

--- a/menu/integrity.menu
+++ b/menu/integrity.menu
@@ -1,3 +1,4 @@
+#! /bin/bash
 ############################################################
 #                                                          #
 # This code is written for Lunar Linux, see                #
@@ -19,43 +20,41 @@
 
 integrity_menu()  {
     INT_TITLE="Integrity Checking Selection Menu"
-     INT_HELP="Please select the tests which lunar fix should execute."
+    INT_HELP="Please select the tests which lunar fix should execute."
     FIND_HELP="Discover missing  binary executables, libraries, and header files"
-     LDD_HELP="Discover broken   binary executables, and libraries"
-     SYM_HELP="Discover misowned symbolic links to files"
-  MD5SUM_HELP="Discover modified binary executables, and libraries"
+    LDD_HELP="Discover broken   binary executables, and libraries"
+    SYM_HELP="Discover misowned symbolic links to files"
+    MD5SUM_HELP="Discover modified binary executables, and libraries"
 
-  if  INT_CHECKS=`$DIALOG  --title  "$INT_TITLE"  \
-                           --no-cancel            \
-                           --item-help            \
-                           --separate-output      \
-                           --checklist            \
-                           "$INT_HELP"            \
-                           0 0 0                  \
+    if  INT_CHECKS=$("$DIALOG"  --title  "$INT_TITLE"        \
+                                --no-cancel                  \
+                                --item-help                  \
+                                --separate-output            \
+                                --checklist                  \
+                                "$INT_HELP"                  \
+                                0 0 0                        \
         "FIND_CHECK"    ""  "$FIND_CHECK"    "$FIND_HELP"    \
         "MD5SUM_CHECK"  ""  "$MD5SUM_CHECK"  "$MD5SUM_HELP"  \
         "LDD_CHECK"     ""  "$LDD_CHECK"     "$LDD_HELP"     \
-        "SYM_CHECK"     ""  "$SYM_CHECK"     "$SYM_HELP"`
+        "SYM_CHECK"     ""  "$SYM_CHECK"     "$SYM_HELP")
   then
-        FIND_CHECK=off
+      FIND_CHECK=off
       MD5SUM_CHECK=off
-         LDD_CHECK=off
-         SYM_CHECK=off
+      LDD_CHECK=off
+      SYM_CHECK=off
 
-    for  CHECK  in  $INT_CHECKS;  do
-      case  $CHECK  in
-          FIND_CHECK)    FIND_CHECK=on  ;;
-        MD5SUM_CHECK)  MD5SUM_CHECK=on  ;;
-           LDD_CHECK)     LDD_CHECK=on  ;;
-           SYM_CHECK)     SYM_CHECK=on  ;;
-      esac
-    done
+      for  CHECK  in  $INT_CHECKS;  do
+          case  $CHECK  in
+              FIND_CHECK)    FIND_CHECK=on  ;;
+              MD5SUM_CHECK)  MD5SUM_CHECK=on  ;;
+              LDD_CHECK)     LDD_CHECK=on  ;;
+              SYM_CHECK)     SYM_CHECK=on  ;;
+          esac
+      done
 
-    set_local_config "FIND_CHECK" "$FIND_CHECK"
-    set_local_config "LDD_CHECK" "$LDD_CHECK"
-    set_local_config "MD5SUM_CHECK" "$MD5SUM_CHECK"
-    set_local_config "SYM_CHECK" "$SYM_CHECK"
-
-  fi
+      set_local_config "FIND_CHECK" "$FIND_CHECK"
+      set_local_config "LDD_CHECK" "$LDD_CHECK"
+      set_local_config "MD5SUM_CHECK" "$MD5SUM_CHECK"
+      set_local_config "SYM_CHECK" "$SYM_CHECK"
+    fi
 }
-

--- a/menu/license.menu
+++ b/menu/license.menu
@@ -1,3 +1,4 @@
+#! /bin/bash
 ############################################################
 #                                                          #
 # This code is written for Lunar Linux, see                #
@@ -18,7 +19,6 @@
 
 set_accepted_licenses()
 {
-
     PROMPT="Please select acceptable licenses
 
 Lunar by default only accept osi-approved licenses. You will
@@ -35,17 +35,15 @@ You have several ways of doing so:
 Currently known osi licenses: gpl gpl2 lgpl gfdl bsd mpl cc apache
 artistic qpl."
 
-    ACCEPTED_LICENSES=`$DIALOG --title "Select accepted licenses" \
-        --ok-label "Commit" --inputbox                            \
-	"$PROMPT" 0 0 "$ACCEPTED_LICENSES"`
+    ACCEPTED_LICENSES=$("$DIALOG" --title "Select accepted licenses" \
+                                  --ok-label "Commit" --inputbox     \
+	                              "$PROMPT" 0 0 "$ACCEPTED_LICENSES")
 
     set_local_config ACCEPTED_LICENSES "$ACCEPTED_LICENSES"
-
 }
 
 set_rejected_licenses()
 {
-
     PROMPT="Please select rejected licenses
 
 Lunar by default only accepts osi-approved licenses. You will
@@ -61,11 +59,9 @@ You have several ways of doing so:
 Remember that if you leave ACCEPTED_LICENSES empty, all licenses will
 be accepted that do not match the REJECTED_LICENSES list."
 
-    REJECTED_LICENSES=`$DIALOG --title "Select rejected licenses" \
-        --ok-label "Commit" --inputbox                            \
-	"$PROMPT" 0 0 "$REJECTED_LICENSES"`
+    REJECTED_LICENSES=$("$DIALOG" --title "Select rejected licenses" \
+                                  --ok-label "Commit" --inputbox     \
+	                              "$PROMPT" 0 0 "$REJECTED_LICENSES")
 
     set_local_config REJECTED_LICENSES "$REJECTED_LICENSES"
-
 }
-

--- a/menu/license.menu
+++ b/menu/license.menu
@@ -31,7 +31,7 @@ You have several ways of doing so:
  o Or enter any specific license name in here to accept it.
  o Enter licenses in the REJECTED_LICENSES and leave this
    field empty to reject only those licenses.
-  
+
 Currently known osi licenses: gpl gpl2 lgpl gfdl bsd mpl cc apache
 artistic qpl."
 

--- a/menu/mirrors.menu
+++ b/menu/mirrors.menu
@@ -1,3 +1,4 @@
+#! /bin/bash
 ############################################################
 #                                                          #
 # This code is written for Lunar Linux, see                #
@@ -29,7 +30,7 @@ select_mirror()  {
            --menu                          \
            ""                              \
            0 80 10                         \
-           $(mirror_list $1)
+           "$(mirror_list "$1")"
 }
 
 mirror_menu()  {
@@ -43,22 +44,21 @@ mirror_menu()  {
     X_HELP="Select mirror for downloading XFree86 related sources."
  XORG_HELP="Select mirror for downloading XOrg related sources."
     N_HELP="Select mirror for downloading NVIDIA drivers."
-      HELP="Selecting a mirror site can speed your downloads."
 
-    COMMAND=`$DIALOG  --title "Mirror Menu"        \
-                      --ok-label      "Select"     \
-                      --cancel-label  "Exit"       \
-                      --item-help                  \
-                      --menu     ""  0 0 0         \
-                      "GNOME"    ""  "$N_HELP"     \
-                      "GNU"      ""  "$G_HELP"     \
-                      "KDE"      ""  "$K_HELP"     \
-                      "KERNEL"   ""  "$L_HELP"     \
-                      "SFORGE"   ""  "$SF_HELP"    \
-                      "LRESORT"  ""  "$LR_HELP"    \
-                      "NVIDIA"   ""  "$N_HELP"     \
-                      "XFREE86"  ""  "$X_HELP"     \
-                      "XORG"     ""  "$XORG_HELP"`
+    COMMAND=$("$DIALOG"  --title "Mirror Menu"        \
+                         --ok-label      "Select"     \
+                         --cancel-label  "Exit"       \
+                         --item-help                  \
+                         --menu     ""  0 0 0         \
+                         "GNOME"    ""  "$N_HELP"     \
+                         "GNU"      ""  "$G_HELP"     \
+                         "KDE"      ""  "$K_HELP"     \
+                         "KERNEL"   ""  "$L_HELP"     \
+                         "SFORGE"   ""  "$SF_HELP"    \
+                         "LRESORT"  ""  "$LR_HELP"    \
+                         "NVIDIA"   ""  "$N_HELP"     \
+                         "XFREE86"  ""  "$X_HELP"     \
+                         "XORG"     ""  "$XORG_HELP")
 
   do
     case  $COMMAND in
@@ -73,7 +73,7 @@ mirror_menu()  {
           LRESORT)  MIRROR=" LRESORT_URL"    ;;
     esac
 
-    if  MIRROR_URL=$(select_mirror $COMMAND);  then
+    if  MIRROR_URL=$(select_mirror "$COMMAND");  then
       if  [  "$MIRROR_URL" == "Custom"  ];  then
          MIRROR_URL=$($DIALOG  --inputbox  "Please enter the URL."  0 0)
       fi
@@ -81,7 +81,7 @@ mirror_menu()  {
       if [ -n "$MIRROR_URL" ] ; then
         set_local_config "$MIRROR" "$MIRROR_URL" &&
         $DIALOG  --msgbox  "$MIRROR=$MIRROR_URL saved in $LOCAL_CONFIG" 8 60
-        export ${MIRROR// }="$MIRROR_URL"
+        export "${MIRROR// }"="$MIRROR_URL"
       fi
     fi
   done


### PR DESCRIPTION
Basically a code cleanup without changing any functionality.

The "shellcheck" utility had many things to say about our code, including the use of outdated constructs like using backticks instead of $() to do output substitution and quoting variables when their values were being used.  I also cleaned up trailing whitespaces and empty lines, and made the indentation more consistent.