### PR TITLE
fix-add-broken-depends: Ensure that it sees a string as a string

### DIFF
--- a/prog/lvu
+++ b/prog/lvu
@@ -499,10 +499,11 @@ moonalyze() {
 
   add_broken_optional_dep() {
     if [[ "$VERBOSE" = "on" ]]; then
-      if [ -z "${broken_optional_deps[$mod:$DEP]}" ]; then
-        broken_optional_deps[$mod:$DEP]=$1
+      key="${mod}:${DEP}"
+      if [ -z "${broken_optional_deps[$key]}" ]; then
+        broken_optional_deps[$key]=$1
       else
-        broken_optional_deps[$mod:$DEP]+=", $1"
+        broken_optional_deps[$key]+=", $1"
       fi
     else
       broken_optional_args=("${broken_optional_args[@]}" "$mod")


### PR DESCRIPTION
Bash has a ?: syntax which can be applied during parameter
expansion. shfmt, which contains a static analyser, identified
this bit of code as being something which could potentially
confuse the parser into thinking it's part of a ternary-operator
sequence.

So I just moved the key, with its colon in it, to a string variable
and removed all potential for confusion.