### PR TITLE
remove broken continue

### DIFF
--- a/libs/modules.lunar
+++ b/libs/modules.lunar
@@ -870,7 +870,6 @@ replace_modules() {
           if query "Do you want replace ${MODULE_COLOR}${IMOD} ${QUERY_COLOR}with ${MODULE_COLOR}${RMOD}${QUERY_COLOR}?${DEFAULT_COLOR}" y; then
             echo "$IMOD" >> $TMP_REM_QUEUE
             echo "$RMOD" >> $TMP_INS_QUEUE
-            continue
           else
             message "${MODULE_COLOR}${IMOD}${DEFAULT_COLOR}${MESSAGE_COLOR} is kept and can be removed or replaced manually later${DEFAULT_COLOR}"
           fi


### PR DESCRIPTION
My bash complained:

> modules.lunar: line 874: continue: only meaningful in a `for', `while', or `until' loop

As there is no code in the loops after that if-else clause I guess this is redundant anyway?