### PR TITLE
do not log updating the moonbase

### DIFF
--- a/libs/moonbase.lunar
+++ b/libs/moonbase.lunar
@@ -88,7 +88,6 @@ SOURCE_URL_FULL=$MOONBASE_URL/$SOURCE
     OUTCOME=success || OUTCOME=failed
   fi
 
-  activity_log "lin" "moonbase" "$VERSION" "$OUTCOME" "$INFO"
   if [ "$OUTCOME" == "failed" ] ; then
     return 1
   fi

--- a/prog/lrm
+++ b/prog/lrm
@@ -209,7 +209,10 @@ lrm_module() {
 
   message "${LRM_COLOR}Removed${EXTEMP} module:" \
     "${MODULE_COLOR}${MODULE}${DEFAULT_COLOR}"
-  activity_log "lrm" "$MODULE" "$VERSION" "success"
+  # do not spam logs just for updating the moonbase
+  if [[ "$MODULE" != "moonbase" ]]; then
+    activity_log  "lrm"  "$MODULE" "$VERSION"  "success"
+  fi
 
   temp_destroy $TMP_DIRS
 }


### PR DESCRIPTION
Possibly a matter of taste.
In case anyone objects, maybe we can make it optional?

My concrete use-case is a server system that automatically fetches the moonbase every few hours to notify me about important updates.
Of course that just adds a lot of useless entries in the activity log.