### PR TITLE
build.lunar: Adding "export PYTHONDONTWRITEBYTECODE=True &&" to the p…

### DIFF
--- a/libs/build.lunar
+++ b/libs/build.lunar
@@ -341,6 +341,7 @@ default_python2_build() {
     local _PYDESTDIR=$SOURCE_DIRECTORY/__pythondest2
     mkdir -p "$_PYDESTDIR"
 
+    export PYTHONDONTWRITEBYTECODE=True &&
     python2 setup.py build &&
     python2 setup.py install --root="$_PYDESTDIR" $OPTS
     prepare_install &&
@@ -354,6 +355,7 @@ default_python3_build() {
     local _PYDESTDIR=$SOURCE_DIRECTORY/__pythondest3
     mkdir -p "$_PYDESTDIR"
 
+    export PYTHONDONTWRITEBYTECODE=True &&
     python3 setup.py build &&
     python3 setup.py install --root="$_PYDESTDIR" $OPTS
     prepare_install &&


### PR DESCRIPTION
…ython 3/2

default build functions. For those modules using the default build it will prevent
the install of pyc files.

To accomplish the same for those modules using different methods to install python
modules the above export line should be inserted in BUILD/PRE_BUILD.