### PR TITLE
lvu depends: Significantly speed things up

### DIFF
--- a/prog/lvu
+++ b/prog/lvu
@@ -1467,8 +1467,10 @@ main() {
       ;;
 
     depends)
-      fill_depends_collection
-      show_depends "$2" | sort -u
+      if [ -n "$2" ]; then
+        fill_depends_collection
+        show_depends "$2" | sort -u
+      fi
       ;;
 
     website)

--- a/prog/lvu
+++ b/prog/lvu
@@ -583,21 +583,33 @@ moonalyze() {
   fi
 }
 
+declare -A DEPENDS_COLLECTION
+
+fill_depends_collection() {
+    local module dependency status rest
+
+    while IFS=: read module dependency status rest
+    do
+        if [ "$status" == "on" ]; then
+            DEPENDS_COLLECTION[$dependency]="${DEPENDS_COLLECTION[$dependency]} $module"
+        fi
+    done < $DEPENDS_STATUS
+}
+
 show_depends() {
-  if ! echo "$DONE" | grep -q "$1"; then
-    DONE="$DONE  $1"
+    local module=$1
 
-    grep ":$1:" "$DEPENDS_STATUS" | while read LINE; do
-      MODULE=${LINE%%:*}
-      STATUS=$(echo $LINE | cut -d : -f3)
+    if [ -z "${DEPENDS_COLLECTION[*]}" ]; then
+        fill_depends_collection
+    fi
 
-      if [ "$STATUS" == "on" ]; then
-        echo $MODULE
-        show_depends $MODULE
-      fi
-
+    local depends=${DEPENDS_COLLECTION[$module]}
+    local submodule
+    for submodule in $depends
+    do
+        echo $submodule
+        show_depends $submodule
     done
-  fi
 }
 
 # function: show_tree
@@ -1459,7 +1471,7 @@ main() {
       ;;
 
     depends)
-      show_depends "$2" | sort | uniq
+      show_depends "$2" | sort -u
       ;;
 
     website)

--- a/prog/lvu
+++ b/prog/lvu
@@ -585,6 +585,7 @@ moonalyze() {
 
 
 fill_depends_collection() {
+    declare -Ag DEPENDS_COLLECTION
     local module dependency status rest
 
     while IFS=: read module dependency status rest

--- a/prog/lvu
+++ b/prog/lvu
@@ -598,13 +598,9 @@ fill_depends_collection() {
 
 show_depends() {
     local module=$1
-
-    if [ -z "${DEPENDS_COLLECTION[*]}" ]; then
-        fill_depends_collection
-    fi
-
     local depends=${DEPENDS_COLLECTION[$module]}
     local submodule
+
     for submodule in $depends
     do
         echo $submodule
@@ -1471,6 +1467,7 @@ main() {
       ;;
 
     depends)
+      fill_depends_collection
       show_depends "$2" | sort -u
       ;;
 

--- a/prog/lvu
+++ b/prog/lvu
@@ -583,7 +583,6 @@ moonalyze() {
   fi
 }
 
-declare -A DEPENDS_COLLECTION
 
 fill_depends_collection() {
     local module dependency status rest


### PR DESCRIPTION
Previously, `lvu depends` would grep through /var/state/lunar/depends,
once for every dependency that it came across, with a potential
combinatorial explosion for something which lots and lots of stuff
depends on (like openssl, or perl).

This gets rid of the invocations of grep, in favor of doing everything
within the same process.  It loads up an associative array with the
relevant contents of /var/state/lunar/depends, and does all of its
operations in RAM instead of having to go through the Lunar depends
state file multiple times (I tried `lvu depends perl` in strace, and it
exec'ed /usr/bin/grep over 14,000 times!).