### PR TITLE
add `lvu activity -f`

### DIFF
--- a/man/lvu.1
+++ b/man/lvu.1
@@ -15,7 +15,10 @@ compile|compiler|links|install|sum|md5sum <module>
 export|import [snapshot]
 .PP 
 .B lvu
-moonbase|html|updatelog|activity
+moonbase|html|updatelog
+.PP 
+.B lvu
+activity [-f] [module]
 .PP 
 .B lvu
 search "phrase"
@@ -201,9 +204,9 @@ prints the entire moonbase in a nice html format
 .IP 
 view summary log of previous lunar update
 .PP
-.B activity
+.B activity [-f] [module]
 .IP
-view the main lunar activity log
+view the main lunar activity log in a pager. If -f is given follow the log file instead of printing it once. If module is given restrict output to this module.
 .PP
 .B search
 "phrase"

--- a/prog/lvu
+++ b/prog/lvu
@@ -1248,7 +1248,10 @@ main() {
       ;;
 
     activity)
-      if [ -e $ACTIVITY_LOG ]; then
+      if [ -e "$ACTIVITY_LOG" ]; then
+        if [ "$LUNAR_FOLLOW_FILE" = "on" ]; then
+          view_file(){ tail -f "$@"; }
+        fi
         if [ -z "$2" ]; then
           view_file "$ACTIVITY_LOG"
         else
@@ -1674,7 +1677,7 @@ main() {
 . /etc/lunar/config
 . $BOOTSTRAP
 
-GETOPT_ARGS=$(getopt -q -n lvu -o "dhv" -l "debug,help,verbose" -- "$@")
+GETOPT_ARGS=$(getopt -q -n lvu -o "dhvf" -l "debug,help,verbose" -- "$@")
 
 if [ -z "$?" ]; then
   help | view_file
@@ -1698,6 +1701,10 @@ else
         ;;
       -v | --verbose)
         export VERBOSE="on"
+        shift
+        ;;
+      -f)
+        export LUNAR_FOLLOW_FILE="on"
         shift
         ;;
       --)


### PR DESCRIPTION
This missing functionality was bugging me for over 10 years I guess...
I got into a habit of doing `tail -f /var/log/lunar/activity` instead,
but having the argument is definitely nicer.

Also I updated a bit of the docs which did not mention the optional module yet.