### PR TITLE
view_file: let the pager handle reading the file

### DIFF
--- a/libs/view.lunar
+++ b/libs/view.lunar
@@ -18,7 +18,7 @@ view_file()  {
          XZ) xzcat $1 | ${PAGER:-less} ;;
           *)
              # default fallback
-             cat "$1" | ${PAGER:-less} ;;
+             ${PAGER:-less} "$1" ;;
     esac
   else
     cat - | ${PAGER:-less}


### PR DESCRIPTION
at least when it's not compressed.

This allows for file-based pager operations such as <shift>f in less.