### PR TITLE
files.lunar: Halfway fix for the loop detector.

### DIFF
--- a/libs/depends.lunar
+++ b/libs/depends.lunar
@@ -94,7 +94,7 @@ sort_by_dependency() {
 
   # tsort the existing dep relations in all of moonbase
   TMP_TSRT=$(temp_create "dependency.sort")
-  awk -F: '{print $1,$2}' "$DEPENDS_CACHE" | while read A B ; do
+  awk -F: '$3 == "on" {print $1,$2}' "$DEPENDS_CACHE" | while read A B ; do
     B=$(MODULE=$A NEVER_ASK=1 DEPS_ONLY= expand_alias $B)
     echo "$A $B" >> $TMP_TSRT
   done

--- a/libs/depends.lunar
+++ b/libs/depends.lunar
@@ -102,8 +102,10 @@ sort_by_dependency() {
   # tell you where the circle is, and certainly can't tell you which
   # optional dependency you selected caused the dependency loop.  Give
   # the user the option of carrying on regardless if a circle is found.
-  if ! tsort "$TMP_TSRT" > /dev/null 2>&1
+  if [[ "${DETECT_DEPENDENCY_LOOPS:-off}" == on ]]
   then
+    if ! tsort "$TMP_TSRT" > /dev/null 2>&1
+    then
       error_message "${PROBLEM_COLOR}Dependency loop detected!${DEFAULT_COLOR}"
       error_message "${PROBLEM_COLOR}You should lin -r one of the modules with optional dependencies.${DEFAULT_COLOR}"
 
@@ -112,8 +114,9 @@ sort_by_dependency() {
       # later on). It's not ideal (definitely a FIXME).
       if [ -t 1 ] && query "Stop now and try again?" y
       then
-          exit 1
+        exit 1
       fi
+    fi
   fi
   tsort "$TMP_TSRT" 2> /dev/null | tac > $TMP_ALL
   temp_destroy $TMP_TSRT

--- a/libs/depends.lunar
+++ b/libs/depends.lunar
@@ -104,9 +104,13 @@ sort_by_dependency() {
   # the user the option of carrying on regardless if a circle is found.
   if ! tsort "$TMP_TSRT" > /dev/null 2>&1
   then
-      message "${PROBLEM_COLOR}Dependency loop detected!${DEFAULT_COLOR}"
-      message "${PROBLEM_COLOR}You should lin -r one of the modules with optional dependencies.${DEFAULT_COLOR}"
-      if query "Stop now and try again?" y
+      error_message "${PROBLEM_COLOR}Dependency loop detected!${DEFAULT_COLOR}"
+      error_message "${PROBLEM_COLOR}You should lin -r one of the modules with optional dependencies.${DEFAULT_COLOR}"
+
+      # "[ -t 1 ]" checks to see if stdout is a terminal
+      # if stdout isn't a terminal, just continue (and probably break
+      # later on). It's not ideal (definitely a FIXME).
+      if [ -t 1 ] && query "Stop now and try again?" y
       then
           exit 1
       fi


### PR DESCRIPTION
First of all, user "error_message" so that the error messages go to
standard error (duh) instead of polluting the input of whatever's
trying to call it.

Second of all, if standard out is a terminal, then ask questions. If
not, just soldier on. As the comment says, this is probably not the
ideal way to proceed.