### PR TITLE
Properly reload plugins if a module dependency installs it

### DIFF
--- a/libs/plugins.lunar
+++ b/libs/plugins.lunar
@@ -86,6 +86,14 @@ update_plugin() {
           debug_msg "Installed \"$(basename $PLUGIN)\""
           install -m644 $PLUGIN $PLUGIN_DIR/
         done
+
+        # Force a reload in the parent lin process,
+        # this is required if a module dependency adds a plugin
+        if [ "$MAIN_PPID" != "$PPID" ]; then
+          kill -HUP $PPID
+        else
+          kill -HUP $$
+        fi
       elif [ "$2" == "remove" ] || ! module_installed $1 ; then
         for PLUGIN in $MOONBASE/$SECTION/$1/plugin.d/*.plugin; do
           debug_msg "Removed \"$(basename $PLUGIN)\""
@@ -97,8 +105,8 @@ update_plugin() {
           install -m644 $PLUGIN $PLUGIN_DIR/
         done
       fi
+      reload_plugins
     fi
-    reload_plugins
   fi
 }
 
@@ -118,7 +126,8 @@ update_plugins() {
 
 reload_plugins() {
     local ITERATOR
-    debug_msg "reload_plugins($@)"
+    debug_msg "reload_plugins($@, TRAP=$TRAP)"
+    verbose_msg "reload_plugins(TRAP=$TRAP)"
 
     # Unload current plugins
     unset LUNAR_PLUGINS

--- a/prog/lin
+++ b/prog/lin
@@ -65,6 +65,12 @@ main() {
   debug_msg "main ($@)"
   MODULES="$@"
 
+  if [ -z "$MAIN_PPID" ]; then
+    export MAIN_PPID=$PPID
+  fi
+
+  trap "TRAP=1 reload_plugins" HUP
+
   # We only run this check once instead of for each module to be installed
   if [ -z "$MODULE" ] && ! check_free_space; then
     if ! query "${WARNING_COLOR}WARNING: ${MESSAGE_COLOR}less than $REQUIRED_FREE_SPACE of free space available in ${FILE_COLOR}$INSTALL_CACHE or $BUILD_DIRECTORY. ${MESSAGE_COLOR}Continue anyway (y/N)?${DEFAULT_COLOR}" n; then


### PR DESCRIPTION
Fixes a module install failure edge case where `mod1` has a dependency on `mod2`, and `mod2` installs a plugin required by `mod1`. This change forces plugins to reload in the following cases: `lin mod1` and `lin mod2 mod1`.