### PR TITLE
plugins.lunar: Don't always send USR1 to $PPID

### DIFF
--- a/libs/plugins.lunar
+++ b/libs/plugins.lunar
@@ -90,7 +90,11 @@ update_plugin() {
         # Force a reload in the parent lin process,
         # this is required if a module dependency adds a plugin
         if [ "$MAIN_PPID" != "$PPID" ]; then
-          kill -USR1 $PPID
+          case $(tr '\0' ' ' < /proc/$PPID/cmdline) in
+            */sbin/lin*)
+              kill -USR1 $PPID
+            ;;
+          esac
         else
           kill -USR1 $$
         fi

--- a/libs/plugins.lunar
+++ b/libs/plugins.lunar
@@ -90,8 +90,8 @@ update_plugin() {
         # Force a reload in the parent lin process,
         # this is required if a module dependency adds a plugin
         if [ "$MAIN_PPID" != "$PPID" ]; then
-          case $(tr '\0' ' ' < /proc/$PPID/cmdline) in
-            */sbin/lin*)
+          case "$(ps -o comm= -p $PPID)" in
+            lin)
               kill -USR1 $PPID
             ;;
           esac


### PR DESCRIPTION
Check to make sure that $PPID is actually a `lin` before telling it to
update its own plugins.  It might be an `lsh` and the USR1 might only
end up confusing things.

Note that this is only a suggestion. There may well be a much better
way to handle this.