### PR TITLE
build.lunar: Make Python stop trying to manage packages

### DIFF
--- a/libs/build.lunar
+++ b/libs/build.lunar
@@ -363,7 +363,7 @@ default_python2_build() {
 
     export PYTHONDONTWRITEBYTECODE=1 &&
     python2 setup.py build &&
-    python2 setup.py install --root="$_PYDESTDIR" $OPTS &&
+    python2 setup.py install --root="$_PYDESTDIR" --single-version-externally-managed $OPTS &&
     prepare_install &&
     cp -rfv --preserve=mode,ownership --remove-destination "$_PYDESTDIR"/* /
 }
@@ -377,7 +377,7 @@ default_python3_build() {
 
     export PYTHONDONTWRITEBYTECODE=1 &&
     python3 setup.py build &&
-    python3 setup.py install --root="$_PYDESTDIR" $OPTS &&
+    python3 setup.py install --root="$_PYDESTDIR" --single-versional-externally-managed $OPTS &&
     prepare_install &&
     cp -rfv --preserve=mode,ownership --remove-destination "$_PYDESTDIR"/* /
 }


### PR DESCRIPTION
Lunar is already a package manager, Python trying to also manage
packages just leads to confusion and annoyance.