### PR TITLE
build.lunar: Even though meson defaults to "setup" when no other comm…

### DIFF
--- a/libs/build.lunar
+++ b/libs/build.lunar
@@ -289,7 +289,7 @@ default_meson_config() {
   verbose_msg "MODULE_PREFIX=\"$MODULE_PREFIX\""
   MESON_BUILD_TYPE=${MESON_BUILD_TYPE:-release}
   verbose_msg "MESON_BUILD_TYPE=\"$MESON_BUILD_TYPE\""
-  meson --prefix $MODULE_PREFIX \
+  meson setup --prefix $MODULE_PREFIX \
         --buildtype $MESON_BUILD_TYPE \
         --default-library shared \
         --libdir lib \

--- a/libs/build.lunar
+++ b/libs/build.lunar
@@ -294,7 +294,7 @@ default_meson_config() {
         --default-library shared \
         --libdir lib \
         $OPTS \
-        . build/
+        . $MODULE-$VERSION/
 }
 
 default_install() {
@@ -329,9 +329,9 @@ default_meson_build() {
   debug_msg "default_meson_build ($@)"
   verbose_msg "running \"default_meson_build\""
   default_meson_config &&
-  ninja -C build/ &&
+  ninja -C $MODULE-$VERSION/ &&
   prepare_install &&
-  ninja -C build/ install
+  ninja -C $MODULE-$VERSION/ install
 }
 
 default_perl_build() {


### PR DESCRIPTION
…and is specified,

I am seeing this warning;
WARNING: Running the setup command as `meson [options]` instead of `meson setup [options]` is ambiguous and deprecated.

This change adds "setup" thus silencing this warning.