### PR TITLE
fix: use depends status file to determine required deps

### DIFF
--- a/libs/depends.lunar
+++ b/libs/depends.lunar
@@ -94,7 +94,7 @@ sort_by_dependency() {
 
   # tsort the existing dep relations in all of moonbase
   TMP_TSRT=$(temp_create "dependency.sort")
-  awk -F: '$3 == "on" {print $1,$2}' "$DEPENDS_CACHE" | while read A B ; do
+  awk -F: '$3 == "on" {print $1,$2}' "$DEPENDS_STATUS" | while read A B ; do
     B=$(MODULE=$A NEVER_ASK=1 DEPS_ONLY= expand_alias $B)
     echo "$A $B" >> $TMP_TSRT
   done


### PR DESCRIPTION
This should fix `sort_by_dependency` which has mirrored the input as a return value for some time.

$DEPENDS_CACHE only contains an overview of all dependencies in moonbase, the "on" status does not exist in that file. $DEPENDS_STATUS does have that though, and it should be safe to use at this stage. `rework_module` is always called first to update $DEPENDS_STATUS before calling `sort_by_dependency`.