### PR TITLE
build.lunar: install libraries in correct path, lib64 to lib

### DIFF
--- a/libs/build.lunar
+++ b/libs/build.lunar
@@ -275,11 +275,12 @@ default_cmake_config() {
 
   cmake_build_target
 
-  cmake -DCMAKE_INSTALL_PREFIX=$MODULE_PREFIX  \
-        -DCMAKE_BUILD_TYPE=RELEASE             \
-        -DSYSCONF_INSTALL_DIR:PATH=/etc        \
-        -DBUILD_TESTING=0                      \
-        -Wno-dev                               \
+  cmake -DCMAKE_INSTALL_PREFIX=$MODULE_PREFIX     \
+        -DCMAKE_INSTALL_LIBDIR=$MODULE_PREFIX/lib \
+        -DCMAKE_BUILD_TYPE=RELEASE                \
+        -DSYSCONF_INSTALL_DIR:PATH=/etc           \
+        -DBUILD_TESTING=0                         \
+        -Wno-dev                                  \
         $OPTS $SOURCE_DIRECTORY
 }
 


### PR DESCRIPTION
This is a fix about tar failing to extract if /usr/lib64 is a symlink, which is the case with default installations of Lunar.